### PR TITLE
Test page layout and functionality enhancements:

### DIFF
--- a/modules/testrunner/app/views/TestRunner/Index.html
+++ b/modules/testrunner/app/views/TestRunner/Index.html
@@ -10,9 +10,12 @@
 		<script src="{{url `Root`}}/@tests/public/js/highlight.pack.js" type="text/javascript"></script>
 		<style>
 		header { padding:20px 0; background-color:#ADD8E6 }
+		button.file-test { margin-bottom: 4px; margin-left: 6px }
+		table.tests tr { border-bottom: 1px solid #ddd; background-color: #f9f9f9; }
+		.table > tbody > tr > td { vertical-align: middle; }
 		.passed td { background-color: #90EE90 !important; }
 		.failed td { background-color: #FFB6C1 !important; }
-		.tests td.name, .tests td.result { padding-top: 13px; }
+		.tests td.name, .tests td.result { }
 		pre { font-size:10px; white-space: pre; }
 		.name { width: 25%; }
 		.w100 { width: 100%; }
@@ -22,24 +25,24 @@
 		<header>
 			<div class="container">
 				<table class="w100"><tr><td>
-					<h1>Test Runner</h1>
-					<p class="lead">Run all of your application's tests from here.</p>
+					<h1>Test Runner <small>- Run your unit tests here.</small> </h1>
 				</td><td style="padding-left:150px;" class="text-right">
-					<button class="btn btn-lg btn-success" all-tests="">Run All Tests</button>
+					<button class="btn btn-success" all-tests="">Run All Tests</button>
 				</td></tr></table>
 			</div>
 		</header>
 
 		<div class="container">
+			<br>
 			{{range .testSuites}}
-				<p class="lead" style="margin-top:20px;">{{.Name}}</p>
-				<table class="table table-striped tests" suite="{{.Name}}">
+			{{ $testFile := .Name }}
+			<button class="btn btn-xs btn-success file-test" test-file="{{.Name}}" class="btn btn-success btn-xs">Run</button>
+			<span class="h4">&nbsp;{{.Name}}</span>
+				<table class="table table-condensed table-striped2 tests" suite="{{.Name}}">
 					{{range .Tests}}
 						<tr>
-							<td class="name">{{.Name}}</td>
-							<td class="result">
-							</td>
-							<td class="text-right"><button test="{{.Name}}" class="btn btn-success">Run</button></td>
+							<td class="name"><button data-test-file="{{$testFile}}" test="{{.Name}}" class="btn btn-success btn-xs">Run</button>&nbsp;&nbsp;{{ .Name }}</td>
+							<td class="result"></td>
 						</tr>
 					{{end}}
 				</table>
@@ -53,6 +56,14 @@
 	$("button[test]").click(function() {
 		var button = $(this).addClass("disabled").text("Running");
 		addToQueue(button);
+	});
+
+	$("button[test-file]").click(function() {
+		var testfile = $(this).attr('test-file');
+		$("button").each(function() {
+			if ($(this).data("test-file") == testfile)
+			    $(this).click();
+		});
 	});
 
 	$("button[all-tests]").click(function() {


### PR DESCRIPTION
   * use condensed layout in order to reduce scrolling
   * move run button to left, e.g. near the test name
   * add button to run all tests in a file
   * remove row striping so that test grouping is more apparent

Note: I tried following the directions in the contribution document but the branch checkout to "develop" didn't work for me. I hope that you can/will accept this request nonetheless. I think that revel is a nifty framework and I would like to make additional contributions to it.

Regards,
Eric Gilbertson

TODO:
   * group tests by dir, e.g. controller, service... and display ordered by names
   * add accordians to show/hide by test dir
![enhanced-testrunner](https://cloud.githubusercontent.com/assets/1987922/6625560/0f5ede60-c8ae-11e4-860b-a4cf5ccbb2b9.png)
